### PR TITLE
fix(host): USB gadget NIC stays DOWN on Ubuntu Server Edition

### DIFF
--- a/src/configure/daemons/host/gadgetini_net_up.service
+++ b/src/configure/daemons/host/gadgetini_net_up.service
@@ -1,18 +1,20 @@
 [Unit]
-Description=Activate gadgetini monitoring system network start up
-Requires=NetworkManager.service
-After=network-online.target
+Description=Bring up gadgetini USB gadget network link
+# The NIC only exists after the Pi enumerates over USB, so bind to the device
+# unit rather than network-online.target. This also re-runs if the Pi is
+# power-cycled and the interface reappears.
+BindsTo=sys-subsystem-net-devices-enxfef11ad36eb7.device
+After=sys-subsystem-net-devices-enxfef11ad36eb7.device
 
 [Service]
-# Bring up the profile created by usb-gadget-host.sh (name was mismatched as
-# "gadgetini" before, which never existed → unit failed while autoconnect still
-# worked). The profile is bound to its ifname, and `|| true` tolerates it already
-# being active via connection.autoconnect.
-ExecStart=/bin/sh -c '/usr/bin/nmcli connection up usb-gadget-host || true'
 Type=oneshot
 RemainAfterExit=yes
-User=root
-Group=root
-[Install]
-WantedBy=multi-user.target
+# `ip` lives in /sbin on Rocky and /usr/sbin on Ubuntu -> resolve via PATH.
+# `addr replace` is a no-op when NetworkManager already owns the same address,
+# which is why this is safe on Desktop as well as Server.
+# No ExecStop: tearing the address down would yank it out from under NM.
+ExecStart=/bin/sh -c 'ip link set dev enxfef11ad36eb7 up'
+ExecStart=/bin/sh -c 'ip -6 addr replace fd12:3456:789a:1::1/64 dev enxfef11ad36eb7'
 
+[Install]
+WantedBy=sys-subsystem-net-devices-enxfef11ad36eb7.device

--- a/src/configure/daemons/host/install-services.sh
+++ b/src/configure/daemons/host/install-services.sh
@@ -11,7 +11,11 @@ SERVICES=(
 )
 
 echo "=== Configuring USB Gadget Network ==="
-sudo bash "${SCRIPT_DIR}/../../../configure/usb_net/usb-gadget-host.sh"
+if command -v nmcli >/dev/null 2>&1 && systemctl is-active --quiet NetworkManager; then
+    sudo bash "${SCRIPT_DIR}/../../../configure/usb_net/usb-gadget-host.sh"
+else
+    echo "  Skipping usb-gadget-host.sh (no NetworkManager); gadgetini_net_up.service will handle the link"
+fi
 echo ""
 
 echo "=== Installing Python venv and dependencies ==="


### PR DESCRIPTION
  ## 문제

  Ubuntu Server에서 gadgetini USB gadget 인터페이스가 `STATE UP` 되지 않습니다.
  NetworkManager를 설치해도 안 됩니다 — Server는 netplan renderer가 `networkd`라 NM이 이더넷을 unmanaged로 두기 때문입니다.

  ## 변경

  NetworkManager 의존을 제거하고 장치 유닛에 직접 결속합니다.

  gadgetini가 USB로 열거
    → sys-subsystem-net-devices-enx….device
    → ip link set … up
    → ip -6 addr replace fd12:…::1/64

  - NIC가 실제로 나타난 뒤에만 실행됩니다.
  - NM 의존이 사라져 netplan 전용 호스트에서도 동작합니다.

  `install-services.sh`는 NM이 있을 때만 `usb-gadget-host.sh`를 실행합니다.
  그 스크립트는 전부 nmcli라 NM 없는 호스트에서는 할 수 있는 일이 없고,
  가드가 없으면 오류만 뿌리고 exit 0으로 끝나 설치가 성공한 것처럼 보입니다.

  ## 검증

  Desktop/Server Host(24.04.4) + gadgetini 연결 상태에서 유닛 `active (exited)`,
  gadgetini ping 손실 0%, Redis 호스트 메트릭 수신 확인.